### PR TITLE
Dockerfile adaptations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+      # Node.js
+      node_modules/
+      npm-debug.log*
+      yarn-debug.log*
+      yarn-error.log*
+      package-lock.json
+      pnpm-lock.yaml
+      .env
+      .env.local
+      .env.*.local
+
+      # Build output
+      dist/
+      target/
+      build/
+      coverage/
+      .out/
+
+      # System files
+      .DS_Store
+      Thumbs.db
+
+      # IDEs and editors
+      .vscode/
+      .idea/
+      *.sw?
+      *.sublime*
+      *.iml
+
+      # Logs
+      logs/
+      *.log
+
+      # OS generated files
+      ehthumbs.db
+      Icon?
+      Desktop.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM openlink/vos:v0
+FROM openlink/virtuoso-opensource-7
+#openlink/vos:v0
 
 ENV CMD2RDF_SRC  git
 ENV CMD2RDF_HOST http://localhost:8080
@@ -8,19 +9,24 @@ ENV PWD=replaceMe
 RUN mkdir -p /opt/virtuoso-opensource/var/lib/virtuoso/db
 ADD virtuoso.ini /opt/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.ini
 
-RUN apt-get -y update && \
-  apt-get -y clean && \
-  apt-get -y install supervisor default-jdk maven tomcat6 curl && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /tmp/*
+RUN apt-get -y update
+RUN apt-get -y clean
+RUN apt-get -y install supervisor
+RUN apt-get -y install openjdk-8-jdk
+RUN apt-get -y install maven
+RUN apt-get -y install tomcat9
+RUN apt-get -y install curl
+RUN apt-get -y install git
+RUN rm -rf /var/lib/apt/lists/*
+RUN rm -rf /tmp/*
   
-# pacify tomcat6
-RUN ln -s /var/lib/tomcat6/server /usr/share/tomcat6/
-RUN ln -s /var/lib/tomcat6/shared /usr/share/tomcat6/
+# pacify tomcat9
+RUN ln -s /var/lib/tomcat9/server /usr/share/tomcat9/
+RUN ln -s /var/lib/tomcat9/shared /usr/share/tomcat9/
 
 # startup scripts
-ADD start-tomcat6.sh /start-tomcat6.sh
-ADD supervisord-tomcat6.conf /etc/supervisor/conf.d/supervisord-tomcat6.conf
+ADD start-tomcat9.sh /start-tomcat9.sh
+ADD supervisord-tomcat9.conf /etc/supervisor/conf.d/supervisord-tomcat9.conf
   
 ADD start-virtuoso.sh /start-virtuoso.sh
 ADD supervisord-virtuoso.conf /etc/supervisor/conf.d/supervisord-virtuoso.conf
@@ -52,7 +58,7 @@ WORKDIR /app/src
 RUN git clone https://github.com/epimorphics/elda.git
 WORKDIR /app/src/elda
 RUN git checkout tags/elda-1.3.1
-RUN mvn clean install
+RUN mvn -DskipTests clean install
 
 # checkout and compile cmd2rdf
 #RUN git clone https://github.com/TheLanguageArchive/CMD2RDF.git
@@ -73,8 +79,8 @@ RUN mvn clean install
 # once more to create webapps/target/Cmd2RdfPageHeader.properties
 RUN mvn install
 # install the WARs
-RUN cp /app/src/CMD2RDF/webapps/target/cmd2rdf.war /var/lib/tomcat6/webapps
-RUN cp /app/src/CMD2RDF/lda/target/cmd2rdf-lda.war /var/lib/tomcat6/webapps
+RUN cp /app/src/CMD2RDF/webapps/target/cmd2rdf.war /var/lib/tomcat9/webapps
+RUN cp /app/src/CMD2RDF/lda/target/cmd2rdf-lda.war /var/lib/tomcat9/webapps
 
 # install the script to import CMD records
 ADD cmd2rdf-init.sh /app/cmd2rdf-init.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,13 +65,6 @@ RUN sed -i "s|http://localhost:8080|$CMD2RDF_HOST|g" /app/ld/*.graph
 # move VLO orgs to the harvester dir
 # NOTE: orgs isn't in the new CLAVAS
 RUN mv /app/ld/meertens-VLO-orgs.rdf /app/work/harvester/meertens-VLO-orgs.rdf
-  
-# Prime the local Maven cache with the required version of elda
-#WORKDIR /app/src
-#RUN git clone https://github.com/epimorphics/elda.git
-#WORKDIR /app/src/elda
-#RUN git checkout tags/elda-1.3.17
-#RUN mvn -s /app/settings.xml -DskipTests clean install
 
 # checkout and compile cmd2rdf
 #RUN git clone https://github.com/TheLanguageArchive/CMD2RDF.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM openlink/virtuoso-opensource-7
 #openlink/vos:v0
 
-ENV CMD2RDF_SRC  git
-ENV CMD2RDF_HOST http://localhost:8080
-ENV CMD2RDF_HOME /app
+ENV CMD2RDF_SRC=git
+ENV CMD2RDF_HOST=http://localhost:8080
+ENV CMD2RDF_HOME=/app
 ENV ADMIN=admin
-ENV PWD=replaceMe
+ENV PWD=secret
 RUN mkdir -p /opt/virtuoso-opensource/var/lib/virtuoso/db
 ADD virtuoso.ini /opt/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.ini
 
@@ -14,19 +14,32 @@ RUN apt-get -y clean
 RUN apt-get -y install supervisor
 RUN apt-get -y install openjdk-8-jdk
 RUN apt-get -y install maven
-RUN apt-get -y install tomcat9
 RUN apt-get -y install curl
 RUN apt-get -y install git
+RUN apt-get -y install wget
+RUN apt-get -y install unzip
 RUN rm -rf /var/lib/apt/lists/*
 RUN rm -rf /tmp/*
-  
-# pacify tomcat9
-RUN ln -s /var/lib/tomcat9/server /usr/share/tomcat9/
-RUN ln -s /var/lib/tomcat9/shared /usr/share/tomcat9/
 
-# startup scripts
-ADD start-tomcat9.sh /start-tomcat9.sh
-ADD supervisord-tomcat9.conf /etc/supervisor/conf.d/supervisord-tomcat9.conf
+# Install Tomcat 6 (we might use 9...but we'll have to install it like below as well,
+# since Tomcat9 is no longer available as a package for Ubuntu)
+WORKDIR /app
+RUN cd && wget https://archive.apache.org/dist/tomcat/tomcat-6/v6.0.53/bin/apache-tomcat-6.0.53.tar.gz && \
+    tar -zxvf apache-tomcat-6.0.53.tar.gz && \
+    mv apache-tomcat-6.0.53 /opt/tomcat6 &&  \
+    rm apache-tomcat-6.0.53.tar.gz && \
+    chmod +x /opt/tomcat6/bin/*.sh
+
+# pacify tomcat9
+#RUN ln -s /var/lib/tomcat9/server /usr/share/tomcat9/
+#RUN ln -s /var/lib/tomcat9/shared /usr/share/tomcat9/
+
+# Add Maven settings file
+ADD settings.xml /app/settings.xml
+
+# Add startup scripts
+ADD start-tomcat6.sh /start-tomcat6.sh
+ADD supervisord-tomcat6.conf /etc/supervisor/conf.d/supervisord-tomcat6.conf
   
 ADD start-virtuoso.sh /start-virtuoso.sh
 ADD supervisord-virtuoso.conf /etc/supervisor/conf.d/supervisord-virtuoso.conf
@@ -53,19 +66,19 @@ RUN sed -i "s|http://localhost:8080|$CMD2RDF_HOST|g" /app/ld/*.graph
 # NOTE: orgs isn't in the new CLAVAS
 RUN mv /app/ld/meertens-VLO-orgs.rdf /app/work/harvester/meertens-VLO-orgs.rdf
   
-# prime the maven cache with elda
-WORKDIR /app/src
-RUN git clone https://github.com/epimorphics/elda.git
-WORKDIR /app/src/elda
-RUN git checkout tags/elda-1.3.1
-RUN mvn -DskipTests clean install
+# Prime the local Maven cache with the required version of elda
+#WORKDIR /app/src
+#RUN git clone https://github.com/epimorphics/elda.git
+#WORKDIR /app/src/elda
+#RUN git checkout tags/elda-1.3.17
+#RUN mvn -s /app/settings.xml -DskipTests clean install
 
 # checkout and compile cmd2rdf
 #RUN git clone https://github.com/TheLanguageArchive/CMD2RDF.git
 ADD get-cmd2rdf.sh /app
 RUN chmod +x /app/get-cmd2rdf.sh
 WORKDIR /app/src
-RUN  /app/get-cmd2rdf.sh
+RUN /app/get-cmd2rdf.sh
 RUN sed -i "s|/app|$CMD2RDF_HOME|g" /app/src/CMD2RDF/webapps/src/main/webapp/WEB-INF/web.xml
 RUN sed -i "s|/app|$CMD2RDF_HOME|g" /app/src/CMD2RDF/batch/src/main/resources/cmd2rdf.xml
 RUN sed -i "s|Put here a strong password!|$PWD|g" /app/src/CMD2RDF/batch/src/main/resources/cmd2rdf.xml
@@ -75,12 +88,13 @@ RUN sed -i "s|ADMIN|${ADMIN}|g" /app/src/CMD2RDF/webapps/src/main/java/nl/knaw/d
 RUN sed -i "s|PWD|${PWD}|g" /app/src/CMD2RDF/webapps/src/main/java/nl/knaw/dans/cmd2rdf/webapps/ui/service/UserService.java
 RUN rm /app/get-cmd2rdf.sh
 WORKDIR /app/src/CMD2RDF
-RUN mvn clean install
+RUN mvn -s /app/settings.xml clean install
 # once more to create webapps/target/Cmd2RdfPageHeader.properties
-RUN mvn install
-# install the WARs
-RUN cp /app/src/CMD2RDF/webapps/target/cmd2rdf.war /var/lib/tomcat9/webapps
-RUN cp /app/src/CMD2RDF/lda/target/cmd2rdf-lda.war /var/lib/tomcat9/webapps
+RUN mvn -s /app/settings.xml install
+
+# Install the WARs
+RUN cp /app/src/CMD2RDF/webapps/target/cmd2rdf.war /opt/tomcat6/webapps
+RUN cp /app/src/CMD2RDF/lda/target/cmd2rdf-lda.war /opt/tomcat6/webapps
 
 # install the script to import CMD records
 ADD cmd2rdf-init.sh /app/cmd2rdf-init.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV CMD2RDF_SRC=git
 ENV CMD2RDF_HOST=http://localhost:8080
 ENV CMD2RDF_HOME=/app
 ENV ADMIN=admin
-ENV PWD=replaceMe
+ENV PASS=replaceMe
 RUN mkdir -p /opt/virtuoso-opensource/var/lib/virtuoso/db
 ADD virtuoso.ini /opt/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.ini
 
@@ -17,7 +17,7 @@ RUN apt-get -y install maven
 RUN apt-get -y install curl
 RUN apt-get -y install git
 RUN apt-get -y install wget
-RUN apt-get -y install unzip
+RUN apt-get -y install bzip2
 RUN rm -rf /var/lib/apt/lists/*
 RUN rm -rf /tmp/*
 
@@ -74,11 +74,11 @@ WORKDIR /app/src
 RUN /app/get-cmd2rdf.sh
 RUN sed -i "s|/app|$CMD2RDF_HOME|g" /app/src/CMD2RDF/webapps/src/main/webapp/WEB-INF/web.xml
 RUN sed -i "s|/app|$CMD2RDF_HOME|g" /app/src/CMD2RDF/batch/src/main/resources/cmd2rdf.xml
-RUN sed -i "s|Put here a strong password!|$PWD|g" /app/src/CMD2RDF/batch/src/main/resources/cmd2rdf.xml
+RUN sed -i "s|Put here a strong password!|${PASS}|g" /app/src/CMD2RDF/batch/src/main/resources/cmd2rdf.xml
 RUN sed -i "s|http://localhost:8080|$CMD2RDF_HOST|g" /app/src/CMD2RDF/batch/src/main/resources/cmd2rdf.xml
 RUN sed -i "s|http://192.168.99.100:8080|$CMD2RDF_HOST|g" /app/src/CMD2RDF/lda/src/main/webapp/specs/cmd2rdf-lda.ttl
 RUN sed -i "s|ADMIN|${ADMIN}|g" /app/src/CMD2RDF/webapps/src/main/java/nl/knaw/dans/cmd2rdf/webapps/ui/service/UserService.java
-RUN sed -i "s|PWD|${PWD}|g" /app/src/CMD2RDF/webapps/src/main/java/nl/knaw/dans/cmd2rdf/webapps/ui/service/UserService.java
+RUN sed -i "s|PWD|${PASS}|g" /app/src/CMD2RDF/webapps/src/main/java/nl/knaw/dans/cmd2rdf/webapps/ui/service/UserService.java
 RUN rm /app/get-cmd2rdf.sh
 WORKDIR /app/src/CMD2RDF
 RUN mvn -s /app/settings.xml clean install

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV CMD2RDF_SRC=git
 ENV CMD2RDF_HOST=http://localhost:8080
 ENV CMD2RDF_HOME=/app
 ENV ADMIN=admin
-ENV PWD=secret
+ENV PWD=replaceMe
 RUN mkdir -p /opt/virtuoso-opensource/var/lib/virtuoso/db
 ADD virtuoso.ini /opt/virtuoso-opensource/var/lib/virtuoso/db/virtuoso.ini
 

--- a/cmd2rdf-cron.sh
+++ b/cmd2rdf-cron.sh
@@ -4,7 +4,7 @@ HOME="/app"
 WORK="/app/work"
 DATA="/app/data/clarin"
 
-SRC="https://vlo.clarin.eu/data/resultsets"
+SRC="https://vlo.clarin.eu/resultsets"
 SET="clarin.tar.bz2"
 
 # make sure expected dirs exist
@@ -39,4 +39,4 @@ tar xjf $WORK/$SET
 
 # start import
 cd $HOME
-exec $HOME/cmd2rdf-run.sh > $WORK/cmd2rdf-`date '+%Y%m%d'`.log 2>&1
+exec $HOME/cmd2rdf-run.sh > $WORK/cmd2rdf-"$(date '+%Y%m%d')".log 2>&1

--- a/get-cmd2rdf.sh
+++ b/get-cmd2rdf.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ $CMD2RDF_SRC = "git" ]; then
-	git clone https://github.com/TheLanguageArchive/CMD2RDF.git
+	git clone https://github.com/knaw-huc/CMD2RDF.git
 else
 	$CMD2RDF_SRC
 fi

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,12 @@
+<!-- Maven settings file -->
+<settings>
+    <mirrors>
+        <!-- Disable Maven HTTP blocking for the public Epimorphics repository -->
+        <mirror>
+            <id>epimorphics-pub-mirror</id>
+            <name>Epimorphics HTTP mirror</name>
+            <url>https://repository.epimorphics.com</url>
+            <mirrorOf>epi-public-repo</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>

--- a/start-tomcat6.sh
+++ b/start-tomcat6.sh
@@ -7,7 +7,7 @@ function shutdown()
     date
     echo "Shutting down Tomcat"
     
-    /etc/init.d/tomcat6 stop
+    /opt/tomcat6/bin/shutdown.sh
 
     WAIT="0"
 }
@@ -15,7 +15,7 @@ function shutdown()
 date
 echo "Starting Tomcat"
 
-/etc/init.d/tomcat6 start
+/opt/tomcat6/bin/startup.sh
 
 # Allow any signal which would kill a process to stop Tomcat
 trap shutdown HUP INT QUIT ABRT KILL ALRM TERM TSTP


### PR DESCRIPTION
- The apt-get install of Tomcat10 installs headless Java 21, which is incompatible with the Epimorphics and CMD2RDF builds (re: SecurityManager), so use a Tomcat 6 (for now?)
- Added Maven settings.xml that overrides the HTTP blocking of the Epimorphics repository by Maven
- Because of the previous item, removed priming of Maven cache with Elda
- Added apt-get install of bzip2
- Replaced var PWD with PASS
- Fixed Clarin crawler results directory in cmd2rdf-cron.sh